### PR TITLE
Corrected Variable Expansion To Meet Style Guide Requirements (#86)

### DIFF
--- a/run_client.sh
+++ b/run_client.sh
@@ -17,10 +17,10 @@
 HOST="$1"
 PORT="$2"
 
-if [[ "$HOST" == "" || "$PORT" == "" ]] ; then
+if [[ "${HOST}" == "" || "${PORT}" == "" ]] ; then
   echo 'usage: <HOST> <PORT>'
   exit 1
 fi
 
 cd './bin'
-java codeu.chat.ClientMain "$HOST@$PORT"
+java codeu.chat.ClientMain "${HOST}@${PORT}"

--- a/run_relay.sh
+++ b/run_relay.sh
@@ -17,15 +17,15 @@
 PORT="$1"
 TEAM_FILE="$2"
 
-if [[ "$PORT" == "" || "$TEAM_FILE" == "" ]] ; then
+if [[ "${PORT}" == "" || "${TEAM_FILE}" == "" ]] ; then
   echo 'usage: <PORT> <TEAM FILE>'
   exit 1
 fi
 
-if [ ! -f "$TEAM_FILE" ] ; then
-  echo "No file at $TEAM_FILE"
+if [ ! -f "${TEAM_FILE}" ] ; then
+  echo "No file at ${TEAM_FILE}"
   exit 1
 fi
 
 cd './bin'
-java codeu.chat.RelayMain "$PORT" "$TEAM_FILE"
+java codeu.chat.RelayMain "${PORT}" "${TEAM_FILE}"

--- a/run_server.sh
+++ b/run_server.sh
@@ -20,7 +20,7 @@ PORT="$3"
 PERSISTENT_DIR="$4"
 RELAY_ADDRESS="$5"
 
-if [[ "$TEAM_ID" == "" || "$TEAM_SECRET" == "" || "$PORT" == "" || "$PERSISTENT_DIR" == "" ]] ; then
+if [[ "${TEAM_ID}" == "" || "${TEAM_SECRET}" == "" || "${PORT}" == "" || "${PERSISTENT_DIR}" == "" ]] ; then
   echo 'usage: <TEAM ID> <TEAM SECRET> <PORT> <PERSISTENT> [RELAY ADDRESS]'
   echo ''
   echo 'TEAM ID :        The id registered with the relay server. If you are'
@@ -41,17 +41,17 @@ fi
 
 
 cd './bin'
-if [ "$RELAY_ADDRESS" == "" ] ; then
+if [ "${RELAY_ADDRESS}" == "" ] ; then
   java codeu.chat.ServerMain \
-      "$TEAM_ID" \
-      "$TEAM_SECRET" \
-      "$PORT" \
-      "$PERSISTENT_DIR"
+      "${TEAM_ID}" \
+      "${TEAM_SECRET}" \
+      "${PORT}" \
+      "${PERSISTENT_DIR}"
 else
   java codeu.chat.ServerMain \
-      "$TEAM_ID" \
-      "$TEAM_SECRET" \
-      "$PORT" \
-      "$PERSISTENT_DIR" \
-      "$RELAY_ADDRESS"
+      "${TEAM_ID}" \
+      "${TEAM_SECRET}" \
+      "${PORT}" \
+      "${PERSISTENT_DIR}" \
+      "${RELAY_ADDRESS}"
 fi

--- a/run_simple_gui_client.sh
+++ b/run_simple_gui_client.sh
@@ -18,4 +18,4 @@ LOCAL_MACHINE="localhost@2007"
 
 cd './bin'
 
-java codeu.chat.SimpleGuiClientMain "$LOCAL_MACHINE"
+java codeu.chat.SimpleGuiClientMain "${LOCAL_MACHINE}"


### PR DESCRIPTION
The original run scripts did not follow the style guide for variable expansion as dictated here (https://google.github.io/styleguide/shell.xml?showone=Variable_expansion#Variable_expansion). Variables in the bash scripts should be bracket-quoted per shell style guide.

Closes #11